### PR TITLE
terminal-char-width 1.0.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
+
+
 [1]: https://github.com/IonicaBizau/terminal-char-width/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,4 @@
+## Documentation
+
+You can see below the API reference of this module.
+

--- a/README.md
+++ b/README.md
@@ -1,31 +1,36 @@
+
 # terminal-char-width [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/terminal-char-width.svg)](https://www.npmjs.com/package/terminal-char-width) [![Downloads](https://img.shields.io/npm/dt/terminal-char-width.svg)](https://www.npmjs.com/package/terminal-char-width) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Get the char width/height proportions in different terminal emulators.
 
-## Installation
+## :cloud: Installation
 
 ```sh
 $ npm i --save terminal-char-width
 ```
 
-## Example
+
+## :clipboard: Example
+
+
 
 ```js
-"use strict";
-
 const terminalCharWidth = require("terminal-char-width");
 
 console.log(terminalCharWidth);
 // => 0.5
 ```
 
-## How to contribute
+## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
-## Where is this library used?
+## :dizzy: Where is this library used?
 If you are using this library in one of your projects, add it in this list. :sparkles:
 
-## License
+
+ - [`image-to-ascii`](https://github.com/IonicaBizau/image-to-ascii)—A Node.JS module that converts images to ASCII art.
+
+## :scroll: License
 
 [MIT][license] © [Ionică Bizău][website]
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "emulators"
   ],
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -30,5 +30,16 @@
   "homepage": "https://github.com/IonicaBizau/terminal-char-width#readme",
   "dependencies": {
     "is-windows": "^0.1.1"
-  }
+  },
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
